### PR TITLE
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+disk-filltest (0.8.1-4) UNRELEASED; urgency=low
+
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Mon, 08 Jun 2020 23:56:27 -0000
+
 disk-filltest (0.8.1-3) unstable; urgency=medium
 
   * Update compat level to 13.

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,5 @@
+---
+Bug-Database: https://github.com/bingmann/disk-filltest/issues
+Bug-Submit: https://github.com/bingmann/disk-filltest/issues/new
+Repository: https://github.com/bingmann/disk-filltest.git
+Repository-Browse: https://github.com/bingmann/disk-filltest


### PR DESCRIPTION
Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/disk-filltest/898bb87f-f50a-4afa-b98e-27d94312caa3.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/898bb87f-f50a-4afa-b98e-27d94312caa3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/898bb87f-f50a-4afa-b98e-27d94312caa3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/898bb87f-f50a-4afa-b98e-27d94312caa3/diffoscope)).
